### PR TITLE
APPS-1726 - Message Stuck on Pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Atlas Messenger Changelog
 
+## 0.8.8
+
+### Enhancements
+
+1. Updated code to support the new change notifications in LayerKit v0.13.3.
+
+### Bug Fixes
+
+1. Fixed declared but undefined boolean values in ATLMConversationViewController.m which caused the messages' state to be stuck at 'pending' on random occasions.
+
 ## 0.8.7
 
 ### New Features 

--- a/Code/Controllers/ATLMApplicationController.m
+++ b/Code/Controllers/ATLMApplicationController.m
@@ -91,12 +91,12 @@ NSString *const ATLMConversationDeletedNotification = @"LSConversationDeletedNot
 
 - (void)layerClient:(LYRClient *)client objectsDidChange:(NSArray *)changes
 {
-    for (NSDictionary *change in changes) {
-        id changedObject = change[LYRObjectChangeObjectKey];
+    for (LYRObjectChange *change in changes) {
+        id changedObject = change.object;
         if (![changedObject isKindOfClass:[LYRConversation class]]) continue;
         
-        LYRObjectChangeType changeType = [change[LYRObjectChangeTypeKey] integerValue];
-        NSString *changedProperty = change[LYRObjectChangePropertyKey];
+        LYRObjectChangeType changeType = change.type;
+        NSString *changedProperty = change.property;
         
         if (changeType == LYRObjectChangeTypeUpdate && [changedProperty isEqualToString:@"metadata"]) {
             [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationMetadataDidChangeNotification object:changedObject];

--- a/Code/Controllers/ATLMApplicationController.m
+++ b/Code/Controllers/ATLMApplicationController.m
@@ -92,22 +92,20 @@ NSString *const ATLMConversationDeletedNotification = @"LSConversationDeletedNot
 - (void)layerClient:(LYRClient *)client objectsDidChange:(NSArray *)changes
 {
     for (LYRObjectChange *change in changes) {
-        id changedObject = change.object;
-        if (![changedObject isKindOfClass:[LYRConversation class]]) continue;
-        
-        LYRObjectChangeType changeType = change.type;
-        NSString *changedProperty = change.property;
-        
-        if (changeType == LYRObjectChangeTypeUpdate && [changedProperty isEqualToString:@"metadata"]) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationMetadataDidChangeNotification object:changedObject];
+        if (![change.object isKindOfClass:[LYRConversation class]]) {
+            continue;
         }
         
-        if (changeType == LYRObjectChangeTypeUpdate && [changedProperty isEqualToString:@"participants"]) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationParticipantsDidChangeNotification object:changedObject];
+        if (change.type == LYRObjectChangeTypeUpdate && [change.property isEqualToString:@"metadata"]) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationMetadataDidChangeNotification object:change.object];
         }
         
-        if (changeType == LYRObjectChangeTypeDelete) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationDeletedNotification object:changedObject];
+        if (change.type == LYRObjectChangeTypeUpdate && [change.property isEqualToString:@"participants"]) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationParticipantsDidChangeNotification object:change.object];
+        }
+        
+        if (change.type == LYRObjectChangeTypeDelete) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:ATLMConversationDeletedNotification object:change.object];
         }
     }
 }

--- a/Code/Controllers/ATLMConversationViewController.m
+++ b/Code/Controllers/ATLMConversationViewController.m
@@ -284,9 +284,9 @@ NSString *const ATLMDetailsButtonLabel = @"Details";
     NSString *statusString = [NSString new];
     if (mutableRecipientStatus.count > 1) {
         __block NSUInteger readCount = 0;
-        __block BOOL delivered;
-        __block BOOL sent;
-        __block BOOL pending;
+        __block BOOL delivered = NO;
+        __block BOOL sent = NO;
+        __block BOOL pending = NO;
         [mutableRecipientStatus enumerateKeysAndObjectsUsingBlock:^(NSString *userID, NSNumber *statusNumber, BOOL *stop) {
             LYRRecipientStatus status = statusNumber.integerValue;
             switch (status) {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Atlas (1.0.6):
-    - LayerKit (>= 0.13.0)
+  - Atlas (1.0.8):
+    - LayerKit (>= 0.13.3)
   - ClusterPrePermissions (0.5.0)
   - Expecta (0.3.2)
   - KIF (3.0.8):
@@ -8,7 +8,7 @@ PODS:
   - KIF/XCTest (3.0.8)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - LayerKit (0.13.2)
+  - LayerKit (0.13.3)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
   - SVProgressHUD (HEAD based on 1.1.3)
@@ -38,14 +38,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/layerhq/LYRCountDownLatch.git
 
 SPEC CHECKSUMS:
-  Atlas: 8c1ded7ff0d3bdcdb49934e2f3cb01525fb977d1
+  Atlas: 8ded03b20e8f2ffc3383983468a304d4ceb50d6b
   ClusterPrePermissions: f7c18aed36022662a05048fffb44b24b9e796cff
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   KIF: 3c2cb8e66fb216f9c3abcd714699411f0256f767
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  LayerKit: 5a5cdfed55b3c56e7a6bb23323ecca1ad1e6183f
+  LayerKit: 212b87bdaa7e3592b7188952e2211404a2f59614
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
 
-COCOAPODS: 0.37.1
+COCOAPODS: 0.37.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - KIF/XCTest (3.0.8)
   - KIFViewControllerActions (1.0.0):
     - KIF (>= 2.0.0)
-  - LayerKit (0.13.0)
+  - LayerKit (0.13.2)
   - LYRCountDownLatch (0.9.0)
   - OCMock (3.1.2)
   - SVProgressHUD (HEAD based on 1.1.3)
@@ -43,9 +43,9 @@ SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   KIF: 3c2cb8e66fb216f9c3abcd714699411f0256f767
   KIFViewControllerActions: 73085acd975ebbfc954f7895ca1aaa9faa36b3c6
-  LayerKit: e8c4abff3198af5f3eab183aaf324e199a302a4e
+  LayerKit: 5a5cdfed55b3c56e7a6bb23323ecca1ad1e6183f
   LYRCountDownLatch: 72a444f729ca5a8c6157c0b58f335a44e6702b48
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
 
-COCOAPODS: 0.37.0
+COCOAPODS: 0.37.1

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -44,13 +44,13 @@
 	<key>LYRBuildInformation</key>
 	<dict>
 		<key>LYRBuildBuilderEmail</key>
-		<string>kcoleman731@gmail.com</string>
+		<string>klemen.verdnik@gmail.com</string>
 		<key>LYRBuildBuilderName</key>
-		<string>Kevin Coleman</string>
+		<string>Klemen Verdnik</string>
 		<key>LYRBuildLayerKitVersion</key>
-		<string>0.10.0-rc3</string>
+		<string>0.13.3</string>
 		<key>LYRBuildShortSha</key>
-		<string>05f6caf</string>
+		<string>e0a3b34</string>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Your location will only be shared in conversations that you choose.</string>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>0.8.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
Fixes an issue where messages appeared to be stuck on _pending_ state. It happens due to uninitialized `BOOL` values `ATLMConversationViewController.m`.