### PR TITLE
APPS-2242 - Users and Session .plist Files Inaccessible Under Data Protection

### DIFF
--- a/Code/Controllers/ATLMPersistenceManager.m
+++ b/Code/Controllers/ATLMPersistenceManager.m
@@ -212,6 +212,11 @@ static NSString *const ATLMOnDiskPersistenceManagerSessionFileName = @"Session.p
     NSString *path = [self usersPath];
     if (![NSKeyedArchiver archiveRootObject:users toFile:path]) return NO;
     self.users = users;
+    NSError *fileAttributeError;
+    BOOL success = [[NSFileManager defaultManager] setAttributes:@{ NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication } ofItemAtPath:path error:&fileAttributeError];
+    if (!success) {
+        NSLog(@"Failed setting the file protection attribute to the file at path '%@' with error=%@", path, fileAttributeError);
+    }
     return YES;
 }
 
@@ -242,7 +247,15 @@ static NSString *const ATLMOnDiskPersistenceManagerSessionFileName = @"Session.p
 {
     NSString *path = [self sessionPath];
     self.session = session;
-    return [NSKeyedArchiver archiveRootObject:session toFile:path];
+    if (![NSKeyedArchiver archiveRootObject:session toFile:path]) {
+        return NO;
+    }
+    NSError *fileAttributeError;
+    BOOL success = [[NSFileManager defaultManager] setAttributes:@{ NSFileProtectionKey : NSFileProtectionCompleteUntilFirstUserAuthentication } ofItemAtPath:path error:&fileAttributeError];
+    if (!success) {
+        NSLog(@"Failed setting the file protection attribute to the file at path '%@' with error=%@", path, fileAttributeError);
+    }
+    return YES;
 }
 
 - (ATLMSession *)persistedSessionWithError:(NSError **)error


### PR DESCRIPTION
JIRA: https://layerhq.atlassian.net/browse/APPS-2252

If Atlas Messenger is launched in background while under data protection, the `users.plist` and `session.plist` files are inaccessible. Which leaves you at the login screen as soon as you respond to the notification.
I added the file attributes in Atlas messenger to both user and session persisting methods, but it's the same – iOS does not give you the access to those files, when the app is launched in background.