### PR TITLE
Podfile | peg to LayerKit 0.21.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,6 +5,7 @@ use_frameworks!
 
 target 'Atlas Messenger' do
   pod 'Atlas', '~> 1.0.23'
+  pod 'LayerKit', '~> 0.21.1'
   pod 'SVProgressHUD'
   pod 'ClusterPrePermissions', '~> 0.1'
 end


### PR DESCRIPTION
Hey guys, just adding a peg to LayerKit 0.21.1 so Atlas doesn't bring down the incompatible 0.22 version until you have time to update the project to 1.0.25. Cheers!