### PR TITLE
Fixed how ATLMConversationViewController uses ‘showViewController’

### DIFF
--- a/Code/Controllers/ATLMConversationViewController.m
+++ b/Code/Controllers/ATLMConversationViewController.m
@@ -267,13 +267,20 @@ NSString *const ATLMDetailsButtonLabel = @"Details";
 
 - (void)showViewController:(UIViewController *)viewController sender:(id)sender
 {
-    // If the `viewController` isn't a UINavigationController, and isn't already inside of a
-    // UINavigationController, modally present it inside of a UINavigationController
-    if (viewController.navigationController == nil && ![viewController isKindOfClass:[UINavigationController class]]) {
+    // If the `viewController` is a UINavigationController, present it.
+    // Do not attempt to push a navigation controller
+    if ([viewController isKindOfClass:[UINavigationController class]]) {
+        [sender presentViewController:viewController animated:true completion:nil];
+        return;
+    }
+    
+    // If `self` is in a navigation controller, push viewController
+    // Otherwise present it in a navigation controller
+    if (self.navigationController != nil) {
+        [self.navigationController pushViewController:viewController animated:true];
+    } else {
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:viewController];
         [sender presentViewController:navigationController animated:true completion:nil];
-    } else { // Otherwise let `super` handle it
-        [super showViewController:viewController sender:sender];
     }
 }
 


### PR DESCRIPTION
There was a mistake hiding another mistake.

## Mistake 1: 
`if (viewController.navigationController == nil && ![viewController isKindOfClass:[UINavigationController class]]) {`

should have read 

`if (self.navigationController == nil && ![viewController isKindOfClass:[UINavigationController class]]) {`

## Mistake 2:
This method does not work with super, since super calls another method which in turn calls this one. (Infinite loop!) So, I handled the 'show' logic completely manually.

---
What this changes:
- When you use 'showViewController' in ATLMConversationViewController now, it will push the VC if there's a navigation controller, otherwise it will present it.
---

It's a good wrapper for showViewController, but it might be the case that we want location and pictures, etc. to be presented modally, even though we're in a UINavigationViewController.

If this is the case, I can update the two lines to use 'presentViewController' directly instead of calling 'showViewController'

# Sources
- https://developer.apple.com/reference/uikit/uiviewcontroller/1621377-showviewcontroller