### PR TITLE
Fix authorization url for heroku app

### DIFF
--- a/Code/Controllers/ATLMAuthenticationProvider.m
+++ b/Code/Controllers/ATLMAuthenticationProvider.m
@@ -95,7 +95,8 @@ NSString *const ATLMListUsersEndpoint = @"/users.json";
     // This is to support Legacy Identity Provider protocol
     [payload setObject:credentials forKey:@"user"];
     
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.baseURL];
+    NSURL* authenticateURL = [NSURL URLWithString: [NSString stringWithFormat: @"%@authenticate", self.baseURL.absoluteString]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:authenticateURL];
     request.HTTPMethod = @"POST";
     request.HTTPBody = [NSJSONSerialization dataWithJSONObject:payload options:0 error:nil];
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];


### PR DESCRIPTION
This PR introduces:
 - Fix for authorization URL according to [readme](https://github.com/layerhq/instastart-identity-provider) of Heroku app . Previously was`yourHerokuQuickStartAppURL.heroku.com`, now it will be `yourHerokuQuickStartAppURL.heroku.com/authorization` in `ATLMAuthenticationProvider`.