### PR TITLE
More reliable auth challenge flow. Sync logging and activity indicator

### DIFF
--- a/Code/Controllers/ATLMApplicationViewController.m
+++ b/Code/Controllers/ATLMApplicationViewController.m
@@ -238,6 +238,8 @@ static void *ATLMApplicationViewControllerObservationContext = &ATLMApplicationV
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLayerClientDidLoseConnectionNotification:) name:LYRClientDidLoseConnectionNotification object:layerController.layerClient];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLayerClientDidAuthenticateNotification:) name:LYRClientDidAuthenticateNotification object:layerController.layerClient];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLayerClientDidDeauthenticateNotification:) name:LYRClientDidDeauthenticateNotification object:layerController.layerClient];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLayerClientWillBeginSynchronizationNotification:) name:LYRClientWillBeginSynchronizationNotification object:layerController.layerClient];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleLayerClientDidFinishSynchronizationNotification:) name:LYRClientDidFinishSynchronizationNotification object:layerController.layerClient];
         
         // Connect the client
         [layerController.layerClient connectWithCompletion:^(BOOL success, NSError * _Nullable error) {
@@ -271,6 +273,10 @@ static void *ATLMApplicationViewControllerObservationContext = &ATLMApplicationV
 {
     // Show HUD with message
     [SVProgressHUD showSuccessWithStatus:@"Connected to Layer"];
+    
+    if (self.layerController.layerClient.currentSession.state == LYRSessionStateChallenged) {
+        [self.layerController refreshAuthentication];
+    }
 }
 
 - (void)handleLayerClientDidDisconnectNotification:(NSNotification *)notification
@@ -293,6 +299,18 @@ static void *ATLMApplicationViewControllerObservationContext = &ATLMApplicationV
 - (void)handleLayerClientDidDeauthenticateNotification:(NSNotification *)notification
 {
     self.state = ATLMApplicationStateCredentialsRequired;
+}
+
+- (void)handleLayerClientWillBeginSynchronizationNotification:(NSNotification *)notification
+{
+    NSLog(@"layerClient will begin synchronization");
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+}
+
+- (void)handleLayerClientDidFinishSynchronizationNotification:(NSNotification *)notification
+{
+    NSLog(@"layerClient did finish synchronization");
+    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
 }
 
 #pragma mark - ATLMRegistrationViewControllerDelegate implementation

--- a/Code/Controllers/ATLMLayerController.h
+++ b/Code/Controllers/ATLMLayerController.h
@@ -97,6 +97,11 @@ typedef NS_ENUM(NSUInteger, ATLMLayerControllerError) {
 - (void)authenticateWithCredentials:(nonnull ATLMUserCredentials *)credentials completion:(nonnull void (^)(LYRSession * _Nonnull session, NSError *_Nullable error))completion;
 
 /**
+ @abstract Refreshes the current authentication by performing the Layer authentication handshake.
+ */
+- (void)refreshAuthentication;
+
+/**
  @abstract Updates the remote notification device token on the underlying `LYRClient` insance.
  @param deviceToken The remote notification device token passed by the app delegate
    upon receiving a device token.

--- a/Code/Controllers/ATLMSettingsViewController.m
+++ b/Code/Controllers/ATLMSettingsViewController.m
@@ -166,7 +166,9 @@ NSString *const ATLMPresenceStatusKey = @"presenceStatus";
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self.layerClient.authenticatedUser removeObserver:self forKeyPath:ATLMPresenceStatusKey];
+    if (self.layerClient.authenticatedUser) {
+        [self.layerClient.authenticatedUser removeObserver:self forKeyPath:ATLMPresenceStatusKey];
+    }
 }
 
 #pragma mark - UITableViewDataSource


### PR DESCRIPTION
This is way to avoid race conditions between connecting and authenticating that may leave your app in a Challenged state. My sample apps used to occasionally get in this bad state, but have been rock solid after weeks of using this implementation.